### PR TITLE
feat: add main menu screen with start and quit options to Snake game

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ pygame.display.set_caption('Snake')
 icon = pygame.image.load('ic_snake.png')
 pygame.display.set_icon(icon)
 
-main_menu(window, width, height)
+main_menu(window, width)
 
 def draw_grid():
     # Add a background color

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import pygame
+from menu import main_menu
 from snake import Snake
 from food import Food
 
@@ -33,6 +34,8 @@ pygame.display.set_caption('Snake')
 # Load an icon for the window.
 icon = pygame.image.load('ic_snake.png')
 pygame.display.set_icon(icon)
+
+main_menu(window, width, height)
 
 def draw_grid():
     # Add a background color

--- a/menu.py
+++ b/menu.py
@@ -1,0 +1,24 @@
+import pygame
+import sys
+
+def main_menu(window, width, height):
+    menu_running = True
+    font = pygame.font.SysFont(None, 60)
+    while menu_running:
+        window.fill((40, 40, 40))
+        title = font.render('Snake Game', True, (200, 200, 100))
+        start = font.render('Press SPACE to Start', True, (180, 180, 180))
+        quit_ = font.render('Press Q to Quit', True, (180, 180, 180))
+        window.blit(title, (width // 2 - title.get_width() // 2, 150))
+        window.blit(start, (width // 2 - start.get_width() // 2, 300))
+        pygame.display.update()
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_SPACE:
+                    menu_running = False
+                elif event.key == pygame.K_q:
+                    pygame.quit()
+                    sys.exit()

--- a/menu.py
+++ b/menu.py
@@ -1,7 +1,7 @@
 import pygame
 import sys
 
-def main_menu(window, width, height):
+def main_menu(window, width):
     menu_running = True
     font = pygame.font.SysFont(None, 60)
     while menu_running:
@@ -11,6 +11,7 @@ def main_menu(window, width, height):
         quit_ = font.render('Press Q to Quit', True, (180, 180, 180))
         window.blit(title, (width // 2 - title.get_width() // 2, 150))
         window.blit(start, (width // 2 - start.get_width() // 2, 300))
+        window.blit(quit_, (width // 2 - quit_.get_width() // 2, 400))
         pygame.display.update()
         for event in pygame.event.get():
             if event.type == pygame.QUIT:


### PR DESCRIPTION
This pull request introduces a main menu to the Snake game, allowing users to start the game or quit from a dedicated menu screen. The most important changes include importing and integrating the `main_menu` function into the game and defining the `main_menu` function in a new `menu.py` file.

### Integration of the main menu:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R2): Imported the `main_menu` function from the new `menu.py` file and called it before the game grid is drawn, ensuring the menu is displayed when the game starts. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R2) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R38-R39)

### Implementation of the main menu:

* [`menu.py`](diffhunk://#diff-9633182b5bc44116a1dad564c96a21924ed7c84ac01a1ef272575d164a3a4703R1-R25): Added a new file defining the `main_menu` function. The menu displays the game title and options to start the game (by pressing SPACE) or quit (by pressing Q). It uses `pygame` for rendering and event handling.