### PR TITLE
Add game over screen functionality and integrate into main game loop

### DIFF
--- a/gameover.py
+++ b/gameover.py
@@ -1,0 +1,26 @@
+import pygame
+import sys
+
+def game_over_screen(window, width, height):
+    font = pygame.font.SysFont(None, 80)
+    small_font = pygame.font.SysFont(None, 50)
+    game_over = True
+    while game_over:
+        window.fill((40, 40, 40))
+        title = font.render('Game Over', True, (200, 60, 60))
+        restart = small_font.render('Press R to Restart', True, (180, 180, 180))
+        quit_ = small_font.render('Press Q to Quit', True, (180, 180, 180))
+        window.blit(title, (width // 2 - title.get_width() // 2, 180))
+        window.blit(restart, (width // 2 - restart.get_width() // 2, 320))
+        window.blit(quit_, (width // 2 - quit_.get_width() // 2, 390))
+        pygame.display.update()
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_r:
+                    game_over = False
+                elif event.key == pygame.K_q:
+                    pygame.quit()
+                    sys.exit()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import pygame
 from menu import main_menu
+from gameover import game_over_screen
 from snake import Snake
 from food import Food
 
@@ -55,7 +56,7 @@ while running:
 
     for event in pygame.event.get():
         if event.type == pygame.QUIT:
-            running = False
+            game_over_screen(window, width, height)
         elif event.type == pygame.KEYDOWN:
             if event.key == pygame.K_LEFT and direction != 'RIGHT':
                 direction = 'LEFT'
@@ -66,7 +67,7 @@ while running:
             elif event.key == pygame.K_DOWN and direction != 'UP':
                 direction = 'DOWN'
             elif event.key == pygame.K_ESCAPE or event.key == pygame.K_q:
-                running = False
+                game_over_screen(window, width, height)
 
     # Move the snake
     snake.move(direction)
@@ -76,11 +77,11 @@ while running:
 
     # Check for collision with window borders
     if head_x < 0 or head_x >= width // tile_size or head_y < 0 or head_y >= height // tile_size:
-        running = False
+        game_over_screen(window, width, height)
 
     # Check if snake collides with itself
     if (head_x, head_y) in snake.body[1:]:
-        running = False
+        game_over_screen(window, width, height)
 
     # Check if snake eats the food
     if head_x == food.x and head_y == food.y:


### PR DESCRIPTION
This pull request introduces a new `game_over_screen` function to improve the game's user experience by providing a dedicated "Game Over" screen. It also integrates this functionality into the main game loop, replacing the previous approach of simply stopping the game.

### New feature: Game Over screen

* [`gameover.py`](diffhunk://#diff-b20f878580d93c08dbd43757eefe98550e1465c566db5a69bb459fe163bee23dR1-R26): Added a new `game_over_screen` function that displays a "Game Over" screen with options to restart the game (press "R") or quit (press "Q"). This feature enhances the user experience by providing clear feedback and options when the game ends.

### Integration of Game Over screen

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R3): Imported the `game_over_screen` function to make it available in the main game logic.
* `main.py`: Replaced instances of `running = False` with calls to `game_over_screen(window, width, height)` in the `draw_grid` function. This ensures the "Game Over" screen is displayed in the following scenarios:
  - When the user closes the game window.
  - When the user presses the "Escape" or "Q" key.
  - When the snake collides with the window borders or itself.