### PR TITLE
Add MIT License and update README download link with correct GitHub username

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nathan Geers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a simple Snake game implemented in Python. You can control the snake usi
 ## Download and Run
 
 No need to install Python or any dependencies!  
-You can download the executable (.exe) from the [Releases](https://github.com/yourusername/snake-game/releases) page and run it directly on Windows.
+You can download the executable (.exe) from the [Releases](https://github.com/NathanGrs00/snake-game/releases) page and run it directly on Windows.
 
 ## License
 


### PR DESCRIPTION
This pull request introduces a new license for the repository and updates the `README.md` file to reflect the correct link for downloading the executable. These changes ensure proper licensing and improve the accuracy of project documentation.

### Licensing:

* Added an `MIT License` to the repository, granting users broad permissions to use, modify, and distribute the software under specified conditions. (`LICENSE`, [LICENSER1-R21](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R1-R21))

### Documentation:

* Updated the `README.md` file to replace the placeholder GitHub username in the download link with the correct username, `NathanGrs00`. (`README.md`, [README.mdL19-R19](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19))